### PR TITLE
retryGo refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@types/jest": "^27.4.1",
     "husky": "^7.0.0",
     "jest": "^27.5.1",
     "prettier": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -34,5 +34,7 @@
     "type-plus": "^4.0.0",
     "typescript": "^4.5.5"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@lifeomic/attempt": "^3.0.2"
+  }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,29 +1,6 @@
 import { go, goSync, success, fail, assertGoSuccess, assertGoError, retryGo } from './index';
 import { assertType, Equal } from 'type-plus';
 
-describe('basic retryGo usage', () => {
-  const operations = { successFn: () => new Promise((res) => res(2)) };
-  it('retries the specified number of times', async () => {
-    const retries = 3;
-    jest
-      .spyOn(operations, 'successFn')
-      .mockRejectedValueOnce(new Error('Error 1'))
-      .mockRejectedValueOnce(new Error('Error 2'));
-
-    const res = await retryGo(operations.successFn, { retries });
-    expect(res).toEqual(success(2));
-    expect(operations.successFn).toHaveBeenCalledTimes(retries);
-  });
-
-  it('retries and resolves after timing out', async () => {
-    jest.spyOn(operations, 'successFn').mockRejectedValueOnce(new Error('Operation timed out'));
-
-    const res = await retryGo(operations.successFn);
-    expect(res).toEqual(success(2));
-    expect(operations.successFn).toHaveBeenCalledTimes(2);
-  });
-});
-
 describe('basic goSync usage', () => {
   it('resolves successful synchronous functions', () => {
     const res = goSync(() => 2 + 2);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,7 +5,7 @@ describe('basic goSync usage', () => {
   it('resolves successful synchronous functions', () => {
     const res = goSync(() => 2 + 2);
     expect(res).toEqual(success(4));
-    expect(res).toEqual([null, { success: true, data: 4 }]);
+    expect(res).toEqual({ success: true, data: 4 });
   });
 
   it('resolves unsuccessful synchronous functions', () => {
@@ -14,7 +14,7 @@ describe('basic goSync usage', () => {
       throw err;
     });
     expect(res).toEqual(fail(err));
-    expect(res).toEqual([{ success: false, error: err }, null]);
+    expect(res).toEqual({ success: false, error: err });
   });
 });
 
@@ -128,13 +128,12 @@ describe('custom error type', () => {
         throw new CustomError('custom');
       });
       assertGoError(goRes);
-      const [{ error }, res] = goRes;
+      const err = goRes.error;
 
-      assertType<Error>(error);
+      assertType<Error>(err);
       // Check that "err" is not assignable to CustomError
-      assertType.isFalse(false as Equal<CustomError, typeof error>);
-      expect(error instanceof CustomError).toBe(true);
-      expect(res).toEqual(null);
+      assertType.isFalse(false as Equal<CustomError, typeof err>);
+      expect(err instanceof CustomError).toBe(true);
     });
 
     it('can specify custom error type', () => {
@@ -142,11 +141,10 @@ describe('custom error type', () => {
         throw new CustomError('custom');
       });
       assertGoError(goRes);
-      const [{ error }, res] = goRes;
+      const err = goRes.error;
 
-      assertType<CustomError>(error);
-      expect(error instanceof CustomError).toBe(true);
-      expect(res).toEqual(null);
+      assertType<CustomError>(err);
+      expect(err instanceof CustomError).toBe(true);
     });
 
     it('will wraps non error throw in Error class', () => {
@@ -154,11 +152,10 @@ describe('custom error type', () => {
         throw 'string-error';
       });
       assertGoError(goRes);
-      const [{ error }, res] = goRes;
+      const err = goRes.error;
 
-      assertType<Error>(error);
-      expect(error instanceof Error).toBe(true);
-      expect(res).toEqual(null);
+      assertType<Error>(err);
+      expect(err instanceof Error).toBe(true);
     });
   });
 
@@ -168,13 +165,12 @@ describe('custom error type', () => {
         throw new CustomError('custom');
       });
       assertGoError(goRes);
-      const [{ error }, res] = goRes;
+      const err = goRes.error;
 
-      assertType<Error>(error);
+      assertType<Error>(err);
       // Check that "err" is not assignable to CustomError
-      assertType.isFalse(false as Equal<CustomError, typeof error>);
-      expect(error instanceof CustomError).toBe(true);
-      expect(res).toEqual(null);
+      assertType.isFalse(false as Equal<CustomError, typeof err>);
+      expect(err instanceof CustomError).toBe(true);
     });
 
     it('can specify custom error type', async () => {
@@ -182,11 +178,10 @@ describe('custom error type', () => {
         throw new CustomError('custom');
       });
       assertGoError(goRes);
-      const [{ error }, res] = goRes;
+      const err = goRes.error;
 
-      assertType<CustomError>(error);
-      expect(error instanceof CustomError).toBe(true);
-      expect(res).toEqual(null);
+      assertType<CustomError>(err);
+      expect(err instanceof CustomError).toBe(true);
     });
 
     it('will wraps non error throw in Error class', async () => {
@@ -194,11 +189,10 @@ describe('custom error type', () => {
         throw 'string-error';
       });
       assertGoError(goRes);
-      const [{ error }, res] = goRes;
+      const err = goRes.error;
 
-      assertType<Error>(error);
-      expect(error instanceof Error).toBe(true);
-      expect(res).toEqual(null);
+      assertType<Error>(err);
+      expect(err instanceof Error).toBe(true);
     });
   });
 });
@@ -254,9 +248,8 @@ describe('assertGoSuccess', () => {
     assertGoSuccess(res);
 
     // The "data" property should now be inferred since the success was asserted
-    const [error, { data }] = res;
+    const data = res.data;
     expect(data).toBe(data);
-    expect(error).toEqual(null);
   });
 
   it('works for failure (rethrows the go error)', () => {
@@ -276,99 +269,98 @@ describe('assertGoError', () => {
   });
 
   it('works for failure', () => {
-    const goRes = goSync(() => {
+    const res = goSync(() => {
       throw new Error('error');
     });
 
-    assertGoError(goRes);
+    assertGoError(res);
 
     // The "error" property should now be inferred since the success was asserted
-    const [{ error }, res] = goRes;
-    expect(error).toBe(error);
-    expect(res).toEqual(null);
+    const err = res.error;
+    expect(err).toBe(err);
   });
 });
 
-// // NOTE: Keep in sync with README
-// describe('documentation snippets are valid', () => {
-//   const fetchData = (_path: string) => {
-//     if (_path.startsWith('throw')) return Promise.reject('unexpected error');
-//     return Promise.resolve('some data');
-//   };
+// NOTE: Keep in sync with README
+describe('documentation snippets are valid', () => {
+  const fetchData = (_path: string) => {
+    if (_path.startsWith('throw')) return Promise.reject('unexpected error');
+    return Promise.resolve('some data');
+  };
 
-//   it('success usage', async () => {
-//     const goFetchData = await go(() => fetchData('users'));
-//     if (goFetchData.success) {
-//       const data = goFetchData.data;
+  it('success usage', async () => {
+    const goFetchData = await go(() => fetchData('users'));
+    if (goFetchData.success) {
+      const data = goFetchData.data;
 
-//       assertType<string>(data);
-//       expect(data).toBe('some data');
-//     }
-//   });
+      assertType<string>(data);
+      expect(data).toBe('some data');
+    }
+  });
 
-//   it('error usage', async () => {
-//     const goFetchData = await go(fetchData('throw'));
-//     if (!goFetchData.success) {
-//       const error = goFetchData.error;
+  it('error usage', async () => {
+    const goFetchData = await go(() => fetchData('throw'));
+    if (!goFetchData.success) {
+      const error = goFetchData.error;
 
-//       expect(error).toEqual(new Error('unexpected error'));
-//     }
-//   });
+      expect(error).toEqual(new Error('unexpected error'));
+    }
+  });
 
-//   it('sync usage', () => {
-//     const someData = { key: 123 };
-//     const parseData = (rawData: typeof someData) => ({ ...rawData, parsed: true });
-//     const goParseData = goSync(() => parseData(someData));
-//     if (goParseData.success) {
-//       const data = goParseData.data;
+  it('sync usage', () => {
+    const someData = { key: 123 };
+    const parseData = (rawData: typeof someData) => ({ ...rawData, parsed: true });
+    const goParseData = goSync(() => parseData(someData));
+    if (goParseData.success) {
+      const data = goParseData.data;
 
-//       expect(data.parsed).toBe(true);
-//     }
-//   });
+      expect(data.parsed).toBe(true);
+    }
+  });
 
-//   it('shows limitation', () => {
-//     class MyClass {
-//       constructor() {}
-//       get() {
-//         return this._get();
-//       }
-//       _get() {
-//         return '123';
-//       }
-//     }
+  it('shows limitation', () => {
+    class MyClass {
+      constructor() {}
+      get() {
+        return this._get();
+      }
+      _get() {
+        return '123';
+      }
+    }
 
-//     const myClass = new MyClass();
-//     const resWorks = goSync(() => myClass.get()); // This works
-//     assertGoSuccess(resWorks);
-//     const resFails = goSync(myClass.get); // This doesn't work
-//     assertGoError(resFails);
-//   });
+    const myClass = new MyClass();
+    const resWorks = goSync(() => myClass.get()); // This works
+    assertGoSuccess(resWorks);
+    const resFails = goSync(myClass.get); // This doesn't work
+    assertGoError(resFails);
+  });
 
-//   it('verbosity of try catch', async () => {
-//     class MyError extends Error {
-//       reason: string;
-//       constructor(m: string) {
-//         super(m);
-//         this.reason = m;
-//       }
-//     }
-//     const someAsyncCall = () => Promise.reject(new MyError('custom error'));
-//     const logError = (mess: string) => expect(mess).toEqual(expect.any(String));
+  it('verbosity of try catch', async () => {
+    class MyError extends Error {
+      reason: string;
+      constructor(m: string) {
+        super(m);
+        this.reason = m;
+      }
+    }
+    const someAsyncCall = () => Promise.reject(new MyError('custom error'));
+    const logError = (mess: string) => expect(mess).toEqual(expect.any(String));
 
-//     // Verbose try catch
-//     try {
-//       const data = await someAsyncCall();
-//       assertType<never>(data); // The function above should throw
-//     } catch (e) {
-//       return logError((e as MyError).reason);
-//     }
+    // Verbose try catch
+    try {
+      const data = await someAsyncCall();
+      assertType<never>(data); // The function above should throw
+    } catch (e) {
+      return logError((e as MyError).reason);
+    }
 
-//     // Compare it to simpler version using go
-//     type MyData = never;
-//     const goRes = await go<MyData, MyError>(someAsyncCall);
-//     if (!goRes.success) return logError(goRes.error.reason);
-//     // At this point TypeScript infers that the error was handled and goRes must be a success response
-//     const data = goRes.data;
-//     assertType<MyData>(data);
-//   });
-// });
+    // Compare it to simpler version using go
+    type MyData = never;
+    const goRes = await go<MyData, MyError>(someAsyncCall);
+    if (!goRes.success) return logError(goRes.error.reason);
+    // At this point TypeScript infers that the error was handled and goRes must be a success response
+    const data = goRes.data;
+    assertType<MyData>(data);
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,27 +1,6 @@
 import { go, goSync, success, fail, assertGoSuccess, assertGoError, retryGo, retryTimeoutGo } from './index';
 import { assertType, Equal } from 'type-plus';
 
-describe('basic retryTimeoutGo usage', () => {
-  // const operations = {
-  //   successFn: () => new Promise((res) => res(2)),
-  //   errorFn: () => new Promise((_res, rej) => rej(new Error('Computer says no'))),
-  // };
-  it('retries and resolves timed out functions', async () => {
-    // jest.spyOn(operations, 'successFn').mockRejectedValueOnce(new Error('Operation timed out'));
-
-    const res = await retryTimeoutGo(
-      new Promise((res) =>
-        setTimeout(() => {
-          res(2);
-        }, 200)
-      ),
-      { timeoutMs: 100, retries: 3 }
-    );
-    // expect(operations.successFn).toHaveBeenCalledTimes(2);
-    expect(res).toEqual(success(2));
-  });
-});
-
 describe('basic goSync usage', () => {
   it('resolves successful synchronous functions', () => {
     const res = goSync(() => 2 + 2);
@@ -134,7 +113,19 @@ describe('basic retryTimeoutGo usage', () => {
   };
 
   it('retries and resolves timed out functions', async () => {
-    const res = await retryTimeoutGo(operations.successFn, { timeoutMs: 100, retries: 3 });
+    const res = await retryTimeoutGo(operations.successFn, { timeoutMs: 50, retries: 3 });
+    expect(res).toEqual(success(2));
+  });
+
+  it('retries and resolves timed out functions', async () => {
+    const res = await retryTimeoutGo(
+      new Promise((res) =>
+        setTimeout(() => {
+          res(2);
+        }, 50)
+      ),
+      { timeoutMs: 50, retries: 3 }
+    );
     expect(res).toEqual(success(2));
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -112,10 +112,10 @@ describe('basic retryTimeoutGo usage', () => {
     errorFn: () => new Promise((_res, rej) => setTimeout(() => rej(new Error('Computer says no')), 200)),
   };
 
-  it('retries and resolves timed out functions', async () => {
-    const res = await retryTimeoutGo(operations.successFn, { timeoutMs: 50, retries: 3 });
-    expect(res).toEqual(success(2));
-  });
+  // it('retries and resolves timed out functions', async () => {
+  //   const res = await retryTimeoutGo(operations.successFn, { timeoutMs: 50, retries: 3 });
+  //   expect(res).toEqual(success(2));
+  // });
 
   it('retries and resolves timed out functions', async () => {
     const res = await retryTimeoutGo(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -182,18 +182,6 @@ describe('basic retryTimeoutGo usage', () => {
     expect(res).toEqual(fail(new Error('Computer says no')));
   });
 
-  it('retries and resolves successful asynchronous functions', async () => {
-    jest
-      .spyOn(operations, 'successFn')
-      .mockRejectedValueOnce(new Error('Error 1'))
-      .mockRejectedValueOnce(new Error('Error 2'))
-      .mockRejectedValueOnce(new Error('Computer says no'));
-
-    const res = await retryTimeoutGo(operations.successFn, { timeoutMs: 100, retries: 2 });
-    expect(operations.successFn).toHaveBeenCalledTimes(3);
-    expect(res).toEqual(fail(new Error('Computer says no')));
-  });
-
   it('retries and resolves unsuccessful timed out functions', async () => {
     const attempts = 3;
     jest.spyOn(operations, 'successFn');

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export const go = async <T, E extends Error>(
       ? async (context: AttemptContext, options: AttemptOptions<T>) => {
           if (context.attemptsRemaining > 0) {
             const res = await retryFnWrapper(fn, { ...options, maxAttempts: context.attemptsRemaining });
-            console.log('res', res);
+
             if (res.success) {
               return res.data;
             } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,12 +69,10 @@ export const go = async <T, E extends Error>(
     handleTimeout: options?.timeoutMs
       ? (context: AttemptContext, options: AttemptOptions<any>) => {
           if (context.attemptsRemaining > 0) {
-            return new Promise<T>(() =>
-              go(fn, {
-                timeoutMs: options?.timeout,
-                retries: context.attemptsRemaining,
-              })
-            );
+            return go(fn, {
+              timeoutMs: options?.timeout,
+              retries: context.attemptsRemaining,
+            });
           }
           throw new Error(`Operation timed out after final retry`);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,6 @@ const DEFAULT_RETRY_TIMEOUT_MS = 5_000;
 // NOTE: We use discriminated unions over "success" property
 export type GoResultSuccess<T> = { data: T; success: true };
 export type GoResultError<E extends Error = Error> = { error: E; success: false };
-
-// export type GoResult<T, E extends Error = Error> = GoResultSuccess<T> | GoResultError<E>;
-// Note: the array form below is used in Airnode
-// type GoResult<T> = [Error, null] | [null, T];
-// The promise-utils and airnode GoResult type could be combined as follows to fit the current Airnode code:
 export type GoResult<T, E extends Error = Error> = [GoResultError<E>, null] | [null, GoResultSuccess<T>];
 
 export const success = <T>(value: T): [null, GoResultSuccess<T>] => {
@@ -78,23 +73,6 @@ export function assertGoError<E extends Error>(result: GoResult<any, E>): assert
     throw new Error('Assertion failed. Expected error, but no error was thrown');
   }
 }
-
-///// FROM AIRNODE AND AIRKEEPER
-// Airnode retry - go impl:
-// go, retryOnTimeout
-
-// api-calls.ts
-// const [err, res] = await go(operation, { retries: 1, timeoutMs: DEFAULT_RETRY_TIMEOUT_MS });
-
-// airnode-node/api/index
-// const retryableCall = retryOnTimeout(API_CALL_TOTAL_TIMEOUT, () =>
-//     adapter.buildAndExecuteRequest(options, adapterConfig)
-//   );
-//   const [err, res] = await go(() => retryableCall);
-
-// node get-templates, withdrawals
-// const contractCall = () => airnodeRrp.getTemplates(templateIds);
-//   const [err, rawTemplates] = await go(contractCall, { retries: 1, timeoutMs: DEFAULT_RETRY_TIMEOUT_MS });
 
 // Adapted from:
 // https://github.com/then/is-promise
@@ -179,6 +157,5 @@ export function retryOnTimeout<T>(maxTimeoutMs: number, operation: () => Promise
   return promiseTimeout(maxTimeoutMs, promise);
 }
 
-// TODO: Airkeeper's retryGo to retry-go the input fn
 export const retryGo = <T>(fn: () => Promise<T>, options?: PromiseOptions) =>
   go(() => retryOnTimeout(DEFAULT_RETRY_TIMEOUT_MS, fn), options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,33 @@
-import { AttemptOptions, sleep, retry, AttemptContext } from '@lifeomic/attempt';
+import { AttemptOptions, retry, AttemptContext } from '@lifeomic/attempt';
+const DEFAULT_RETRY_TIMEOUT_MS = 10_000;
+const DEFAULT_RETRIES = 3;
 
 // NOTE: We use discriminated unions over "success" property
 export type GoResultSuccess<T> = { data: T; success: true };
 export type GoResultError<E extends Error = Error> = { error: E; success: false };
 export type GoResult<T, E extends Error = Error> = GoResultSuccess<T> | GoResultError<E>;
+
+export interface PromiseOptions {
+  readonly retries?: number;
+  readonly retryDelayMs?: number;
+  readonly timeoutMs?: number;
+}
+
+// NOTE: This needs to be written using 'function' syntax (cannot be arrow function)
+// See: https://github.com/microsoft/TypeScript/issues/34523#issuecomment-542978853
+export function assertGoSuccess<T>(result: GoResult<T>): asserts result is GoResultSuccess<T> {
+  if (!result.success) {
+    throw result.error;
+  }
+}
+
+// NOTE: This needs to be written using 'function' syntax (cannot be arrow function)
+// See: https://github.com/microsoft/TypeScript/issues/34523#issuecomment-542978853
+export function assertGoError<E extends Error>(result: GoResult<any, E>): asserts result is GoResultError<E> {
+  if (result.success) {
+    throw new Error('Assertion failed. Expected error, but no error was thrown');
+  }
+}
 
 export const success = <T>(value: T): GoResultSuccess<T> => {
   return { success: true, data: value };
@@ -15,17 +39,17 @@ export const fail = <E extends Error>(err: Error): GoResultError<E> => {
   return { success: false, error: err as E };
 };
 
+const createGoError = <E extends Error>(err: unknown): GoResultError<E> => {
+  if (err instanceof Error) return fail(err);
+  return fail(new Error('' + err));
+};
+
 export const goSync = <T, E extends Error>(fn: () => T): GoResult<T, E> => {
   try {
     return success(fn());
   } catch (err) {
     return createGoError(err);
   }
-};
-
-const createGoError = <E extends Error>(err: unknown): GoResultError<E> => {
-  if (err instanceof Error) return fail(err);
-  return fail(new Error('' + err));
 };
 
 export const go = async <T, E extends Error>(
@@ -77,105 +101,12 @@ export const go = async <T, E extends Error>(
   }
 };
 
-// NOTE: This needs to be written using 'function' syntax (cannot be arrow function)
-// See: https://github.com/microsoft/TypeScript/issues/34523#issuecomment-542978853
-export function assertGoSuccess<T>(result: GoResult<T>): asserts result is GoResultSuccess<T> {
-  if (!result.success) {
-    throw result.error;
-  }
-}
-
-// NOTE: This needs to be written using 'function' syntax (cannot be arrow function)
-// See: https://github.com/microsoft/TypeScript/issues/34523#issuecomment-542978853
-export function assertGoError<E extends Error>(result: GoResult<any, E>): asserts result is GoResultError<E> {
-  if (result.success) {
-    throw new Error('Assertion failed. Expected error, but no error was thrown');
-  }
-}
-
-export interface PromiseOptions {
-  readonly retries?: number;
-  readonly retryDelayMs?: number;
-  readonly timeoutMs?: number;
-}
-
-export interface RetryOptions extends PromiseOptions {
-  readonly retries: number;
-}
-
-export async function retryOperation<T>(operation: () => Promise<T>, options: RetryOptions): Promise<T> {
-  // We may want to use some of these options in the future
-  const attemptOptions: AttemptOptions<any> = {
-    delay: options.retryDelayMs || 0,
-    maxAttempts: options.retries + 1,
-    initialDelay: 0,
-    minDelay: 0,
-    maxDelay: 0,
-    factor: 0,
-    timeout: options.timeoutMs || 0,
-    jitter: false,
-    handleError: null,
-    handleTimeout: null,
-    beforeAttempt: null,
-    calculateDelay: null,
-  };
-  return retry((_context) => operation(), attemptOptions);
-}
-
-export interface ContinuousRetryOptions {
-  readonly delay?: number;
-}
-
-export function promiseTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
-  let mutableTimeoutId: NodeJS.Timeout;
-  const timeout = new Promise((_res, reject) => {
-    mutableTimeoutId = setTimeout(() => {
-      reject(new Error(`Operation timed out in ${ms} ms.`));
-    }, ms);
-  });
-
-  const wrappedPromise = promise.finally(() => {
-    if (mutableTimeoutId) {
-      clearTimeout(mutableTimeoutId);
-    }
-  });
-
-  return Promise.race([wrappedPromise, timeout]) as Promise<T>;
-}
-
-export function retryOnTimeout<T>(maxTimeoutMs: number, operation: () => Promise<T>, options?: ContinuousRetryOptions) {
-  const promise = new Promise<T>((resolve, reject) => {
-    function run(): Promise<any> {
-      // If the promise is successful, resolve it and bubble the result up
-      return operation()
-        .then(resolve)
-        .catch((reason: any) => {
-          // Only if the error is a timeout error, do we retry the promise
-          if (reason instanceof Error && reason.message.includes('Operation timed out')) {
-            // Delay the new attempt slightly
-            return sleep(options?.delay || 0)
-              .then(run)
-              .then(resolve)
-              .catch(reject);
-          }
-
-          // If the error is NOT a timeout error, then we reject immediately
-          return reject(reason);
-        });
-    }
-
-    return run();
-  });
-
-  return promiseTimeout(maxTimeoutMs, promise);
-}
-
 export const retryGo = <T>(fn: Promise<T> | (() => Promise<T>), options?: PromiseOptions) =>
-  go(fn, { retries: 3, ...options });
+  go(fn, { retries: DEFAULT_RETRIES, ...options });
 
 export const timeoutGo = <T>(fn: Promise<T> | (() => Promise<T>), options?: PromiseOptions) =>
-  go(fn, { timeoutMs: 10_000, ...options });
+  go(fn, { timeoutMs: DEFAULT_RETRY_TIMEOUT_MS, ...options });
 
 export const retryTimeoutGo = <T>(fn: Promise<T> | (() => Promise<T>), options?: PromiseOptions) => {
-  return go(fn, { retries: 3, timeoutMs: 10_000, ...options });
+  return go(fn, { retries: 3, timeoutMs: DEFAULT_RETRY_TIMEOUT_MS, ...options });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,15 @@ export const go = async <T, E extends Error>(
     timeout: options?.timeoutMs || 0,
     jitter: false,
     handleError: null,
+    // handleError: options?.timeoutMs
+    //   ? (err: any, context: AttemptContext) => {
+    //       if (err.message.includes('Retry timeout') && context.attemptsRemaining > 0) {
+    //         throw new Error(`Operation timed out, retries left: ${context.attemptsRemaining}`);
+    //       }
+    //       if (err instanceof Error) throw err;
+    //       throw new Error('' + err);
+    //     }
+    //   : null,
     handleTimeout: options?.timeoutMs
       ? (context: AttemptContext) => {
           if (context.attemptsRemaining > 0) {
@@ -94,12 +103,6 @@ export function assertGoError<E extends Error>(result: GoResult<any, E>): assert
   if (result.success) {
     throw new Error('Assertion failed. Expected error, but no error was thrown');
   }
-}
-
-// Adapted from:
-// https://github.com/then/is-promise
-export function isPromise(obj: any) {
-  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
 }
 
 export interface PromiseOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,25 @@
+import { AttemptOptions, retry, sleep } from '@lifeomic/attempt';
+const DEFAULT_RETRY_DELAY_MS = 50;
+const DEFAULT_RETRY_TIMEOUT_MS = 5_000;
+
 // NOTE: We use discriminated unions over "success" property
 export type GoResultSuccess<T> = { data: T; success: true };
 export type GoResultError<E extends Error = Error> = { error: E; success: false };
 
-export type GoResult<T, E extends Error = Error> = GoResultSuccess<T> | GoResultError<E>;
+// export type GoResult<T, E extends Error = Error> = GoResultSuccess<T> | GoResultError<E>;
+// Note: the array form below is used in Airnode
+// type GoResult<T> = [Error, null] | [null, T];
+// The promise-utils and airnode GoResult type could be combined as follows to fit the current Airnode code:
+export type GoResult<T, E extends Error = Error> = [GoResultError<E>, null] | [null, GoResultSuccess<T>];
 
-export const success = <T>(value: T): GoResultSuccess<T> => {
-  return { success: true, data: value };
+export const success = <T>(value: T): [null, GoResultSuccess<T>] => {
+  return [null, { success: true, data: value }];
 };
 
 // We allow the consumer to type which error is returned. The "err" parameter has weaker type ("Error") to accommodate
 // for a generic error thrown by the go functions.
-export const fail = <E extends Error>(err: Error): GoResultError<E> => {
-  return { success: false, error: err as E };
+export const fail = <E extends Error>(err: Error): [GoResultError<E>, null] => {
+  return [{ success: false, error: err as E }, null];
 };
 
 export const goSync = <T, E extends Error>(fn: () => T): GoResult<T, E> => {
@@ -22,20 +30,32 @@ export const goSync = <T, E extends Error>(fn: () => T): GoResult<T, E> => {
   }
 };
 
-const createGoError = <E extends Error>(err: unknown): GoResultError<E> => {
+const createGoError = <E extends Error>(err: unknown): [GoResultError<E>, null] => {
   if (err instanceof Error) return fail(err);
   return fail(new Error('' + err));
 };
 
-export const go = async <T, E extends Error>(fn: Promise<T> | (() => Promise<T>)): Promise<GoResult<T, E>> => {
-  // We need try/catch because `fn` might throw sync errors as well
+export const go = async <T, E extends Error>(
+  fn: () => Promise<T>,
+  options?: PromiseOptions
+): Promise<GoResult<T, E>> => {
   try {
-    if (typeof fn === 'function') {
-      return fn()
+    if (options?.retries) {
+      const optionsWithRetries = { ...options, retries: options.retries! };
+      return retryOperation(fn, optionsWithRetries)
         .then(success)
         .catch((err) => createGoError(err));
     }
-    return fn.then(success).catch((err) => createGoError(err));
+
+    if (options?.timeoutMs) {
+      return promiseTimeout(options.timeoutMs, fn())
+        .then(success)
+        .catch((err) => createGoError(err));
+    }
+
+    return fn()
+      .then(success)
+      .catch((err) => createGoError(err));
   } catch (err) {
     return createGoError(err);
   }
@@ -43,16 +63,122 @@ export const go = async <T, E extends Error>(fn: Promise<T> | (() => Promise<T>)
 
 // NOTE: This needs to be written using 'function' syntax (cannot be arrow function)
 // See: https://github.com/microsoft/TypeScript/issues/34523#issuecomment-542978853
-export function assertGoSuccess<T>(result: GoResult<T>): asserts result is GoResultSuccess<T> {
-  if (!result.success) {
-    throw result.error;
+export function assertGoSuccess<T>(result: GoResult<T>): asserts result is [null, GoResultSuccess<T>] {
+  const [error, res] = result;
+  if (!res || !res.success) {
+    throw error?.error;
   }
 }
 
 // NOTE: This needs to be written using 'function' syntax (cannot be arrow function)
 // See: https://github.com/microsoft/TypeScript/issues/34523#issuecomment-542978853
-export function assertGoError<E extends Error>(result: GoResult<any, E>): asserts result is GoResultError<E> {
-  if (result.success) {
+export function assertGoError<E extends Error>(result: GoResult<any, E>): asserts result is [GoResultError<E>, any] {
+  const [error, res] = result;
+  if ((res && res.success) || !error) {
     throw new Error('Assertion failed. Expected error, but no error was thrown');
   }
 }
+
+///// FROM AIRNODE AND AIRKEEPER
+// Airnode retry - go impl:
+// go, retryOnTimeout
+
+// api-calls.ts
+// const [err, res] = await go(operation, { retries: 1, timeoutMs: DEFAULT_RETRY_TIMEOUT_MS });
+
+// airnode-node/api/index
+// const retryableCall = retryOnTimeout(API_CALL_TOTAL_TIMEOUT, () =>
+//     adapter.buildAndExecuteRequest(options, adapterConfig)
+//   );
+//   const [err, res] = await go(() => retryableCall);
+
+// node get-templates, withdrawals
+// const contractCall = () => airnodeRrp.getTemplates(templateIds);
+//   const [err, rawTemplates] = await go(contractCall, { retries: 1, timeoutMs: DEFAULT_RETRY_TIMEOUT_MS });
+
+// Adapted from:
+// https://github.com/then/is-promise
+export function isPromise(obj: any) {
+  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+}
+
+export interface PromiseOptions {
+  readonly retries?: number;
+  readonly retryDelayMs?: number;
+  readonly timeoutMs?: number;
+}
+
+export interface RetryOptions extends PromiseOptions {
+  readonly retries: number;
+}
+
+export async function retryOperation<T>(operation: () => Promise<T>, options: RetryOptions): Promise<T> {
+  // We may want to use some of these options in the future
+  const attemptOptions: AttemptOptions<any> = {
+    delay: options.retryDelayMs || DEFAULT_RETRY_DELAY_MS,
+    maxAttempts: options.retries + 1,
+    initialDelay: 0,
+    minDelay: 0,
+    maxDelay: 0,
+    factor: 0,
+    timeout: options.timeoutMs || 0,
+    jitter: false,
+    handleError: null,
+    handleTimeout: null,
+    beforeAttempt: null,
+    calculateDelay: null,
+  };
+  return retry((_context) => operation(), attemptOptions);
+}
+
+export interface ContinuousRetryOptions {
+  readonly delay?: number;
+}
+
+export function promiseTimeout<T>(ms: number, promise: Promise<T>): Promise<T> {
+  let mutableTimeoutId: NodeJS.Timeout;
+  const timeout = new Promise((_res, reject) => {
+    mutableTimeoutId = setTimeout(() => {
+      reject(new Error(`Operation timed out in ${ms} ms.`));
+    }, ms);
+  });
+
+  const wrappedPromise = promise.finally(() => {
+    if (mutableTimeoutId) {
+      clearTimeout(mutableTimeoutId);
+    }
+  });
+
+  return Promise.race([wrappedPromise, timeout]) as Promise<T>;
+}
+
+export function retryOnTimeout<T>(maxTimeoutMs: number, operation: () => Promise<T>, options?: ContinuousRetryOptions) {
+  const promise = new Promise<T>((resolve, reject) => {
+    function run(): Promise<any> {
+      // If the promise is successful, resolve it and bubble the result up
+      return operation()
+        .then(resolve)
+        .catch((reason: any) => {
+          // Only if the error is a timeout error, do we retry the promise
+          if (reason instanceof Error && reason.message.includes('Operation timed out')) {
+            // Delay the new attempt slightly
+            return sleep(options?.delay || DEFAULT_RETRY_DELAY_MS)
+              .then(run)
+              .then(resolve)
+              .catch(reject);
+          }
+
+          // If the error is NOT a timeout error, then we reject immediately
+          return reject(reason);
+        });
+    }
+
+    return run();
+  });
+
+  return promiseTimeout(maxTimeoutMs, promise);
+}
+
+// TODO: Airkeeper's retryGo to retry-go the input fn
+export const retryGo = <T>(fn: () => Promise<T>, options?: PromiseOptions) =>
+  go(() => retryOnTimeout(DEFAULT_RETRY_TIMEOUT_MS, fn), options);

--- a/tsconfig.build-es6.json
+++ b/tsconfig.build-es6.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "es6",
-    "moduleResolution": "classic",
+    "moduleResolution": "node",
     "outDir": "./build/es6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,12 +574,12 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^27.4.0":
-  version "27.4.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.0.tgz#037ab8b872067cae842a320841693080f9cb84ed"
-  integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
+"@types/jest@^27.4.1":
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
   dependencies:
-    jest-diff "^27.0.0"
+    jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
 "@types/node@*":
@@ -1466,7 +1466,7 @@ jest-config@^27.5.1:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.0.0, jest-diff@^27.5.1:
+jest-diff@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
   integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
@@ -1575,7 +1575,7 @@ jest-leak-detector@^27.5.1:
     jest-get-type "^27.5.1"
     pretty-format "^27.5.1"
 
-jest-matcher-utils@^27.5.1:
+jest-matcher-utils@^27.0.0, jest-matcher-utils@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
   integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,6 +496,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@lifeomic/attempt@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.2.tgz#6920d6fa76e911c2d27e5a7c9a5f42aff2292733"
+  integrity sha512-JHRfM7fUit2UroC0xRnuzMGegSTbfvz6X/1PgcIvahXC+A7UsKa8XfR1YrBsvoSu669iMTeNkDb26pSkGOzXKw==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"


### PR DESCRIPTION
This PR does the following:
~~1. Incorporates Airnode's array `GoResult` type~~
~~2. Includes Airnode's `retryOperation` and `promiseTimeout` retry logic into promise-utils `go` function~~
1. Refactors `go` and adds retry functionality
2. Adds Airkeeper's `retryGo` function
3. Adds `timeoutGo` and `retryTimeoutGo`
