### PR TITLE
Use custom error object for non error thrown values

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ The default values for `PromiseOptions` are:
 
 By default, the `timeoutMs` value of `0` means that there is no timeout limit.
 
+The last exported value is a `GoWrappedError` class which wraps an error which happens in go callback. The difference
+between `GoWrappedError` and regular `Error` class is that you can access `GoWrappedError.cause` to get the original
+value which was thrown by the function.
+
 Take a look at the [implementation](https://github.com/api3dao/promise-utils/blob/main/src/index.ts) and
 [tests](https://github.com/api3dao/promise-utils/blob/main/src/index.test.ts) for detailed examples and usage.
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The default values for `PromiseOptions` are:
 By default, the `timeoutMs` value of `0` means that there is no timeout limit.
 
 The last exported value is a `GoWrappedError` class which wraps an error which happens in go callback. The difference
-between `GoWrappedError` and regular `Error` class is that you can access `GoWrappedError.cause` to get the original
+between `GoWrappedError` and regular `Error` class is that you can access `GoWrappedError.reason` to get the original
 value which was thrown by the function.
 
 Take a look at the [implementation](https://github.com/api3dao/promise-utils/blob/main/src/index.ts) and

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -372,7 +372,7 @@ it('has access to native error', async () => {
   // The error message is the  not very useful stringified data
   expect(goRes.error).toEqual(new Error('[object Object]'));
   expect(goRes.error instanceof GoWrappedError).toBeTruthy();
-  expect(goRes.error.cause).toEqual({ message: 'an error', data: 'some data' });
+  expect(goRes.error.reason).toEqual({ message: 'an error', data: 'some data' });
 });
 
 // NOTE: Keep in sync with README

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { go, goSync, success, fail, assertGoSuccess, assertGoError } from './index';
+import { go, goSync, success, fail, assertGoSuccess, assertGoError, GoWrappedError } from './index';
 import { assertType, Equal } from 'type-plus';
 
 describe('basic goSync usage', () => {
@@ -359,6 +359,20 @@ describe('assertGoError', () => {
     const err = res.error;
     expect(err).toBe(err);
   });
+});
+
+it('has access to native error', async () => {
+  const throwingFn = async () => {
+    throw { message: 'an error', data: 'some data' };
+  };
+
+  const goRes = await go<never, GoWrappedError>(throwingFn);
+
+  assertGoError(goRes);
+  // The error message is the  not very useful stringified data
+  expect(goRes.error).toEqual(new Error('[object Object]'));
+  expect(goRes.error instanceof GoWrappedError).toBeTruthy();
+  expect(goRes.error.cause).toEqual({ message: 'an error', data: 'some data' });
 });
 
 // NOTE: Keep in sync with README

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ export interface PromiseOptions {
 }
 
 export class GoWrappedError extends Error {
-  constructor(public cause: unknown) {
-    super('' + cause);
+  constructor(public reason: unknown) {
+    super('' + reason);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,12 @@ export interface PromiseOptions {
   readonly timeoutMs?: number;
 }
 
+export class GoWrappedError extends Error {
+  constructor(public cause: unknown) {
+    super('' + cause);
+  }
+}
+
 // NOTE: This needs to be written using 'function' syntax (cannot be arrow function)
 // See: https://github.com/microsoft/TypeScript/issues/34523#issuecomment-542978853
 export function assertGoSuccess<T>(result: GoResult<T>): asserts result is GoResultSuccess<T> {
@@ -39,7 +45,7 @@ export const fail = <E extends Error>(err: Error): GoResultError<E> => {
 
 const createGoError = <E extends Error>(err: unknown): GoResultError<E> => {
   if (err instanceof Error) return fail(err);
-  return fail(new Error('' + err));
+  return fail(new GoWrappedError(err));
 };
 
 export const goSync = <T, E extends Error>(fn: () => T): GoResult<T, E> => {


### PR DESCRIPTION
While working on an unrelated feature I found a limitation of go utils when the value thrown by the go callback is not a regular error.

Currently we stringify it, but sometimes you want to access that value as raw. This enables this use case (see test).