### PR TITLE
Cancel scheduled timeouts after getting result

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -137,7 +137,8 @@ module.exports = {
   // snapshotSerializers: [],
 
   // The test environment that will be used for testing
-  testEnvironment: 'jsdom',
+  testEnvironment: 'jest-environment-node',
+  // testEnvironment: 'jsdom',
 
   // Options that will be passed to the testEnvironment
   // testEnvironmentOptions: {},


### PR DESCRIPTION
While implementing the tests for Airkeeper I found out that despite handling the promises correctly, we are not clearing the scheduled timers when we already have the result. The implication can be seen for example in:
a) a warning in jest tests (see screenshot)
b) waiting for nodejs process to end (it needs to finish the scheduled timers)

This PR implements a "cancellable promise" and stops delays when they are no longer necessary.

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/22679154/162641858-b42c9cab-625a-4cfc-8c09-70b079fd8bce.png">
