### PR TITLE
Add the ability to specify the timeout for each attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and the following Typescript types:
 - ```ts
   interface GoAsyncOptions<E extends Error = Error> {
     retries?: number; // Number of retries to attempt if the go callback is unsuccessful.
-    attemptTimeoutMs?: number; // The timeout for each attempt.
+    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt.
     totalTimeoutMs?: number; // The maximum timeout for all attempts and delays. No more retries are performed after this timeout.
     delay?: StaticDelayOptions | RandomDelayOptions; // Type of the delay before each attempt. There is no delay before the first request.
     onAttemptError?: (goRes: GoResultError<E>) => void; // Callback invoked after each failed attempt is completed. This callback does not fire for the last attempt or when a "totalTimeoutMs" is exceeded (these should be handled explicitly with the result of "go" call).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and the following Typescript types:
 - ```ts
   interface GoAsyncOptions<E extends Error = Error> {
     retries?: number; // Number of retries to attempt if the go callback is unsuccessful.
-    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts i.e [1000, 2000, 3000] with 5 retries will result in timeouts of 1000, 2000, 3000, 3000, 3000, 3000.
+    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts, if the length of the array is longer than the number of retries, the extra values are ignored.
     totalTimeoutMs?: number; // The maximum timeout for all attempts and delays. No more retries are performed after this timeout.
     delay?: StaticDelayOptions | RandomDelayOptions; // Type of the delay before each attempt. There is no delay before the first request.
     onAttemptError?: (goRes: GoResultError<E>) => void; // Callback invoked after each failed attempt is completed. This callback does not fire for the last attempt or when a "totalTimeoutMs" is exceeded (these should be handled explicitly with the result of "go" call).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and the following Typescript types:
 - ```ts
   interface GoAsyncOptions<E extends Error = Error> {
     retries?: number; // Number of retries to attempt if the go callback is unsuccessful.
-    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt.
+    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts.
     totalTimeoutMs?: number; // The maximum timeout for all attempts and delays. No more retries are performed after this timeout.
     delay?: StaticDelayOptions | RandomDelayOptions; // Type of the delay before each attempt. There is no delay before the first request.
     onAttemptError?: (goRes: GoResultError<E>) => void; // Callback invoked after each failed attempt is completed. This callback does not fire for the last attempt or when a "totalTimeoutMs" is exceeded (these should be handled explicitly with the result of "go" call).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and the following Typescript types:
 - ```ts
   interface GoAsyncOptions<E extends Error = Error> {
     retries?: number; // Number of retries to attempt if the go callback is unsuccessful.
-    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts o.e [1000, 2000, 3000] with 5 retries will result in timeouts of 1000, 2000, 3000, 3000, 3000.
+    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts i.e [1000, 2000, 3000] with 5 retries will result in timeouts of 1000, 2000, 3000, 3000, 3000, 3000.
     totalTimeoutMs?: number; // The maximum timeout for all attempts and delays. No more retries are performed after this timeout.
     delay?: StaticDelayOptions | RandomDelayOptions; // Type of the delay before each attempt. There is no delay before the first request.
     onAttemptError?: (goRes: GoResultError<E>) => void; // Callback invoked after each failed attempt is completed. This callback does not fire for the last attempt or when a "totalTimeoutMs" is exceeded (these should be handled explicitly with the result of "go" call).

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ and the following Typescript types:
 - ```ts
   interface GoAsyncOptions<E extends Error = Error> {
     retries?: number; // Number of retries to attempt if the go callback is unsuccessful.
-    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts.
+    attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts o.e [1000, 2000, 3000] with 5 retries will result in timeouts of 1000, 2000, 3000, 3000, 3000.
     totalTimeoutMs?: number; // The maximum timeout for all attempts and delays. No more retries are performed after this timeout.
     delay?: StaticDelayOptions | RandomDelayOptions; // Type of the delay before each attempt. There is no delay before the first request.
     onAttemptError?: (goRes: GoResultError<E>) => void; // Callback invoked after each failed attempt is completed. This callback does not fire for the last attempt or when a "totalTimeoutMs" is exceeded (these should be handled explicitly with the result of "go" call).

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -181,8 +181,8 @@ describe('basic retry and timeout usage', () => {
     const start = performance.now();
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15, 25], retries: 3 });
     const end = performance.now();
-    expect(end - start).toBeGreaterThanOrEqual(5 + 10 + 15 + 20 - 2);
-    expect(end - start).toBeLessThanOrEqual(5 + 10 + 15 + 20 + 2);
+    expect(end - start).toBeGreaterThanOrEqual(5 + 10 + 15 + 20);
+    expect(end - start).toBeLessThanOrEqual(5 + 10 + 15 + 20 + 5);
     expect(operations.successFn).toHaveBeenCalledTimes(4);
     expect(res).toEqual(success(2));
   });
@@ -214,22 +214,20 @@ describe('basic retry and timeout usage', () => {
     const start = performance.now();
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15], retries: 2 });
     const end = performance.now();
-    expect(end - start).toBeGreaterThan(5 + 10 + 15 - 2);
-    expect(end - start).toBeLessThan(5 + 10 + 15 + 2);
+    expect(end - start).toBeGreaterThan(5 + 10 + 15);
+    expect(end - start).toBeLessThan(5 + 10 + 15 + 5);
     expect(operations.successFn).toHaveBeenCalledTimes(attempts);
     expect(res).toEqual(fail(new Error('Operation timed out')));
   });
 
   it('retries and timeouts within the timeout limit of each attempt', async () => {
-    const attempts = 3;
     jest.spyOn(operations, 'successFn');
-
     const start = performance.now();
-    const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15], retries: 2 });
+    const res = await go(operations.successFn, { attemptTimeoutMs: [5, 8, 10, 12, 15, 18], retries: 5 });
     const end = performance.now();
-    expect(end - start).toBeGreaterThan(5 + 10 + 15 - 2);
-    expect(end - start).toBeLessThan(5 + 10 + 15 + 2);
-    expect(operations.successFn).toHaveBeenCalledTimes(attempts);
+    expect(end - start).toBeGreaterThan(5 + 8 + 10 + 12 + 15 + 18);
+    expect(end - start).toBeLessThan(5 + 8 + 10 + 12 + 15 + 18 + 5);
+    expect(operations.successFn).toHaveBeenCalledTimes(6);
     expect(res).toEqual(fail(new Error('Operation timed out')));
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -179,7 +179,11 @@ describe('basic retry and timeout usage', () => {
 
   it('retries and resolves successful asynchronous functions with varying timeouts', async () => {
     jest.spyOn(operations, 'successFn');
+    const start = performance.now();
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15, 25], retries: 3 });
+    const end = performance.now();
+    expect(end - start).toBeGreaterThanOrEqual(5 + 10 + 15 + 20 - 2);
+    expect(end - start).toBeLessThanOrEqual(5 + 10 + 15 + 20 + 2);
     expect(operations.successFn).toHaveBeenCalledTimes(4);
     expect(res).toEqual(success(2));
   });
@@ -208,7 +212,11 @@ describe('basic retry and timeout usage', () => {
     const attempts = 3;
     jest.spyOn(operations, 'successFn');
 
+    const start = performance.now();
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15], retries: 2 });
+    const end = performance.now();
+    expect(end - start).toBeGreaterThan(5 + 10 + 15 - 2);
+    expect(end - start).toBeLessThan(5 + 10 + 15 + 2);
     expect(operations.successFn).toHaveBeenCalledTimes(attempts);
     expect(res).toEqual(fail(new Error('Operation timed out')));
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -176,6 +176,13 @@ describe('basic retry and timeout usage', () => {
     expect(res).toEqual(success(2));
   });
 
+  it('retries and resolves successful asynchronous functions with varying timeouts', async () => {
+    jest.spyOn(operations, 'successFn');
+    const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15, 25], retries: 3 });
+    expect(operations.successFn).toHaveBeenCalledTimes(4);
+    expect(res).toEqual(success(2));
+  });
+
   it('retries and resolves unsuccessful asynchronous functions', async () => {
     jest
       .spyOn(operations, 'errorFn')
@@ -191,7 +198,7 @@ describe('basic retry and timeout usage', () => {
     const attempts = 3;
     jest.spyOn(operations, 'successFn');
 
-    const res = await go(operations.successFn, { attemptTimeoutMs: 5, retries: 2 });
+    const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15], retries: 2 });
     expect(operations.successFn).toHaveBeenCalledTimes(attempts);
     expect(res).toEqual(fail(new Error('Operation timed out')));
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -198,6 +198,15 @@ describe('basic retry and timeout usage', () => {
     const attempts = 3;
     jest.spyOn(operations, 'successFn');
 
+    const res = await go(operations.successFn, { attemptTimeoutMs: 5, retries: 2 });
+    expect(operations.successFn).toHaveBeenCalledTimes(attempts);
+    expect(res).toEqual(fail(new Error('Operation timed out')));
+  });
+
+  it('retries with multiple timeout durations and resolves unsuccessful timed out functions', async () => {
+    const attempts = 3;
+    jest.spyOn(operations, 'successFn');
+
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15], retries: 2 });
     expect(operations.successFn).toHaveBeenCalledTimes(attempts);
     expect(res).toEqual(fail(new Error('Operation timed out')));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,5 @@
 import { go, goSync, success, fail, assertGoSuccess, assertGoError, GoWrappedError } from './index';
 import { assertType, Equal } from 'type-plus';
-import { performance } from 'perf_hooks';
 
 const expectToBeAround = (actual: number, expected: number, range = 10) => {
   expect(actual).toBeGreaterThanOrEqual(expected - range);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -181,7 +181,7 @@ describe('basic retry and timeout usage', () => {
     const start = performance.now();
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15, 25], retries: 3 });
     const end = performance.now();
-    expect(end - start).toBeGreaterThanOrEqual(5 + 10 + 15 + 20);
+    expect(end - start).toBeGreaterThanOrEqual(5 + 10 + 15 + 20 - 5);
     expect(end - start).toBeLessThanOrEqual(5 + 10 + 15 + 20 + 5);
     expect(operations.successFn).toHaveBeenCalledTimes(4);
     expect(res).toEqual(success(2));
@@ -214,7 +214,7 @@ describe('basic retry and timeout usage', () => {
     const start = performance.now();
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10, 15], retries: 2 });
     const end = performance.now();
-    expect(end - start).toBeGreaterThan(5 + 10 + 15);
+    expect(end - start).toBeGreaterThan(5 + 10 + 15 - 5);
     expect(end - start).toBeLessThan(5 + 10 + 15 + 5);
     expect(operations.successFn).toHaveBeenCalledTimes(attempts);
     expect(res).toEqual(fail(new Error('Operation timed out')));
@@ -225,20 +225,20 @@ describe('basic retry and timeout usage', () => {
     const start = performance.now();
     const res = await go(operations.successFn, { attemptTimeoutMs: [5, 8, 10, 12, 15, 18], retries: 5 });
     const end = performance.now();
-    expect(end - start).toBeGreaterThan(5 + 8 + 10 + 12 + 15 + 18);
+    expect(end - start).toBeGreaterThan(5 + 8 + 10 + 12 + 15 + 18 - 5);
     expect(end - start).toBeLessThan(5 + 8 + 10 + 12 + 15 + 18 + 5);
     expect(operations.successFn).toHaveBeenCalledTimes(6);
     expect(res).toEqual(fail(new Error('Operation timed out')));
   });
 
   it('retries with multiple timeout durations and uses the last value if array length is smaller than total attempts', async () => {
-    const attempts = 3;
+    const attempts = 6;
     jest.spyOn(operations, 'successFn');
     const start = performance.now();
-    const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10], retries: 2 });
+    const res = await go(operations.successFn, { attemptTimeoutMs: [5, 10], retries: 5 });
     const end = performance.now();
-    expect(end - start).toBeGreaterThan(5 + 10 + 10 - 2);
-    expect(end - start).toBeLessThan(5 + 10 + 10 + 2);
+    expect(end - start).toBeGreaterThan(5 + 10 + 10 + 10 + 10 + 10 - 5);
+    expect(end - start).toBeLessThan(5 + 10 + 10 + 10 + 10 + 10 + 5);
     expect(operations.successFn).toHaveBeenCalledTimes(attempts);
     expect(res).toEqual(fail(new Error('Operation timed out')));
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export const go = async <T, E extends Error>(
       // if a single timeout is provided, use it for all attempts
       let currentAttemptTimeoutMs: number | undefined;
       if (Array.isArray(attemptTimeoutMs)) {
-        currentAttemptTimeoutMs = attemptTimeoutMs[i] || attemptTimeoutMs[attemptTimeoutMs.length - 1];
+        currentAttemptTimeoutMs = attemptTimeoutMs[i] || attemptTimeoutMs.at(-1);
       } else {
         currentAttemptTimeoutMs = attemptTimeoutMs;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export interface RandomDelayOptions {
 
 export interface GoAsyncOptions<E extends Error = Error> {
   retries?: number; // Number of retries to attempt if the go callback is unsuccessful.
-  attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts i.e [1000, 2000, 3000] with 5 retries will result in timeouts of 1000, 2000, 3000, 3000, 3000, 3000.
+  attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts, if the length of the array is longer than the number of retries, the extra values are ignored.
   totalTimeoutMs?: number; // The maximum timeout for all attempts and delays. No more retries are performed after this timeout.
   delay?: StaticDelayOptions | RandomDelayOptions; // Type of the delay before each attempt. There is no delay before the first request.
   onAttemptError?: (goRes: GoResultError<E>) => void; // Callback invoked after each failed attempt is completed. This callback does not fire for the last attempt or when a "totalTimeoutMs" is exceeded (these should be handled explicitly with the result of "go" call).

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,11 +166,7 @@ export const go = async <T, E extends Error>(
       // if a single timeout is provided, use it for all attempts
       let currentAttemptTimeoutMs: number | undefined;
       if (Array.isArray(attemptTimeoutMs)) {
-        if (i < attemptTimeoutMs.length) {
-          currentAttemptTimeoutMs = attemptTimeoutMs[i];
-        } else {
-          currentAttemptTimeoutMs = attemptTimeoutMs[attemptTimeoutMs.length - 1];
-        }
+        currentAttemptTimeoutMs = attemptTimeoutMs[i] || attemptTimeoutMs[attemptTimeoutMs.length - 1];
       } else {
         currentAttemptTimeoutMs = attemptTimeoutMs;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,12 +161,19 @@ export const go = async <T, E extends Error>(
     const attempts = retries ? retries + 1 : 1;
     let lastFailedAttemptResult: GoResultError<E> | null = null;
     for (let i = 0; i < attempts; i++) {
-      // if array of timeouts is provided, use the current one, otherwise use the default one
-      const currentAttemptTimeoutMs = Array.isArray(attemptTimeoutMs)
-        ? i < attemptTimeoutMs.length
-          ? attemptTimeoutMs[i]
-          : attemptTimeoutMs[0]
-        : attemptTimeoutMs;
+      // if array of timeouts is provided, use the timeout at the current index,
+      // or the last one if the index is out of bounds
+      // if a single timeout is provided, use it for all attempts
+      let currentAttemptTimeoutMs: number | undefined;
+      if (Array.isArray(attemptTimeoutMs)) {
+        if (i < attemptTimeoutMs.length) {
+          currentAttemptTimeoutMs = attemptTimeoutMs[i];
+        } else {
+          currentAttemptTimeoutMs = attemptTimeoutMs[attemptTimeoutMs.length - 1];
+        }
+      } else {
+        currentAttemptTimeoutMs = attemptTimeoutMs;
+      }
       // Return early in case the global timeout has been exceeded during after attempt wait time.
       //
       // This is guaranteed to be false for the first attempt.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export interface RandomDelayOptions {
 
 export interface GoAsyncOptions<E extends Error = Error> {
   retries?: number; // Number of retries to attempt if the go callback is unsuccessful.
-  attemptTimeoutMs?: number | number[]; // The timeout for each attempt.
+  attemptTimeoutMs?: number | number[]; // The timeout for each attempt. Can provide an array for different timeouts for each attempt. If the array is shorter than the number of retries, the last value is used for all remaining attempts i.e [1000, 2000, 3000] with 5 retries will result in timeouts of 1000, 2000, 3000, 3000, 3000, 3000.
   totalTimeoutMs?: number; // The maximum timeout for all attempts and delays. No more retries are performed after this timeout.
   delay?: StaticDelayOptions | RandomDelayOptions; // Type of the delay before each attempt. There is no delay before the first request.
   onAttemptError?: (goRes: GoResultError<E>) => void; // Callback invoked after each failed attempt is completed. This callback does not fire for the last attempt or when a "totalTimeoutMs" is exceeded (these should be handled explicitly with the result of "go" call).


### PR DESCRIPTION
in this airnode issue: https://github.com/api3dao/airnode/issues/1658 , we wanted to have specific timeouts for each attempt. There are ways to do it there but I think adding this feature to promise-utils makes more sense. This still accepts a single number for the default timeout across all attempts so it is not a breaking change