### PR TITLE
Replace .at(-1) with array[length-1] for ES2022 compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export const go = async <T, E extends Error>(
       // if a single timeout is provided, use it for all attempts
       let currentAttemptTimeoutMs: number | undefined;
       if (Array.isArray(attemptTimeoutMs)) {
-        currentAttemptTimeoutMs = attemptTimeoutMs[i] || attemptTimeoutMs.at(-1);
+        currentAttemptTimeoutMs = attemptTimeoutMs[i] || attemptTimeoutMs[attemptTimeoutMs.length - 1];
       } else {
         currentAttemptTimeoutMs = attemptTimeoutMs;
       }


### PR DESCRIPTION
Closes #186

This was an easy one so gave it to Copilot and it looks good (original PR in my fork [here](https://github.com/dcroote/promise-utils/pull/2) but because I will delete the fork, copied below):

CI failing on TypeScript compilation due to `Array.at()` method usage, which requires ES2022 lib support.

## Changes
- Replaced `attemptTimeoutMs.at(-1)` with `attemptTimeoutMs[attemptTimeoutMs.length - 1]` in `src/index.ts:169`

**Before:**
```typescript
currentAttemptTimeoutMs = attemptTimeoutMs[i] || attemptTimeoutMs.at(-1);
```

**After:**
```typescript
currentAttemptTimeoutMs = attemptTimeoutMs[i] || attemptTimeoutMs[attemptTimeoutMs.length - 1];
```

Both expressions access the last array element. The latter works with ES5+ without requiring lib configuration changes.
